### PR TITLE
Remove destructive type substitution from mlis

### DIFF
--- a/lib/upgrader.ml
+++ b/lib/upgrader.ml
@@ -658,13 +658,14 @@ let make ~prefix ~old_file ~old_file_version ~new_file ~new_file_version =
       [%string
         {|
 include $user_fns_module
-type $converter = $upgrader_t.$module_name.$converter|}]
+type $converter = $upgrader_t.$module_name.$converter
+|}]
     in
     let intf_header =
       [%string
         {|module $old_version : (module type of $old_version_t)
 module $new_version : (module type of $new_version_t)
-type $converter := $upgrader_t.$module_name.$converter|}]
+type $converter = $upgrader_t.$module_name.$converter|}]
     in
     let upgrader_t_header =
       [%string

--- a/test/_snapshots/Generator.077de3bb.0.snapshot
+++ b/test/_snapshots/Generator.077de3bb.0.snapshot
@@ -3,7 +3,7 @@ Generator › simple transitive change - user intf list snapshot
 module From_1_to_2 : sig
 module OldVersion : (module type of Simple_transitive_change_1_t)
 module NewVersion : (module type of Simple_transitive_change_2_t)
-type converter := Simple_transitive_change_upgrader_t.From_1_to_2.converter
+type converter = Simple_transitive_change_upgrader_t.From_1_to_2.converter
 val convert_skill: converter -> OldVersion.employee -> OldVersion.skill -> NewVersion.skill
 val convert_company: converter -> OldVersion.employee -> OldVersion.company -> NewVersion.company
 end

--- a/test/_snapshots/Generator.280d3627.0.snapshot
+++ b/test/_snapshots/Generator.280d3627.0.snapshot
@@ -7,6 +7,7 @@ module From_1_to_2 = struct
 
 include Simple_transitive_change_user_fns.From_1_to_2
 type converter = Simple_transitive_change_upgrader_t.From_1_to_2.converter
+
 let convert_employer: converter -> OldVersion.employee -> OldVersion.employer -> NewVersion.employer = fun converter old_doc -> function 
 | OldVersion.Self -> NewVersion.Self
 | OldVersion.Company payload -> NewVersion.Company (payload |> (convert_company converter old_doc))

--- a/test/_snapshots/Generator.2ad8cc04.0.snapshot
+++ b/test/_snapshots/Generator.2ad8cc04.0.snapshot
@@ -3,7 +3,7 @@ Generator › rescript simple - user intf list snapshot
 module From_1_to_2 : sig
 module OldVersion : (module type of Rescript_simple_1_t)
 module NewVersion : (module type of Rescript_simple_2_t)
-type converter := Rescript_simple_upgrader_t.From_1_to_2.converter
+type converter = Rescript_simple_upgrader_t.From_1_to_2.converter
 val convert_skill: converter -> OldVersion.employee -> OldVersion.skill -> NewVersion.skill
 val convert_company: converter -> OldVersion.employee -> OldVersion.company -> NewVersion.company
 end

--- a/test/_snapshots/Generator.41f036fa.0.snapshot
+++ b/test/_snapshots/Generator.41f036fa.0.snapshot
@@ -6,7 +6,7 @@ val read_employee: Types.employee Atdgen_codec_runtime.Decode.t
 module From_1_to_2 : sig
 module OldVersion : (module type of Rescript_simple_1_t)
 module NewVersion : (module type of Rescript_simple_2_t)
-type converter := Rescript_simple_upgrader_t.From_1_to_2.converter
+type converter = Rescript_simple_upgrader_t.From_1_to_2.converter
 val converter: converter
 val convert: OldVersion.employee -> NewVersion.employee
 end

--- a/test/_snapshots/Generator.5e881dba.0.snapshot
+++ b/test/_snapshots/Generator.5e881dba.0.snapshot
@@ -7,14 +7,14 @@ val read_dialog_file: Yojson.Safe.lexer_state -> Lexing.lexbuf -> Types.dialog_f
 module From_202008241_to_202103001 : sig
 module OldVersion : (module type of Realistic_202008241_t)
 module NewVersion : (module type of Realistic_202103001_t)
-type converter := Realistic_upgrader_t.From_202008241_to_202103001.converter
+type converter = Realistic_upgrader_t.From_202008241_to_202103001.converter
 val converter: converter
 val convert: OldVersion.dialog_file -> NewVersion.dialog_file
 end
 module From_202103001_to_202103115 : sig
 module OldVersion : (module type of Realistic_202103001_t)
 module NewVersion : (module type of Realistic_202103115_t)
-type converter := Realistic_upgrader_t.From_202103001_to_202103115.converter
+type converter = Realistic_upgrader_t.From_202103001_to_202103115.converter
 val converter: converter
 val convert: OldVersion.dialog_file -> NewVersion.dialog_file
 end

--- a/test/_snapshots/Generator.6e7eb4f2.0.snapshot
+++ b/test/_snapshots/Generator.6e7eb4f2.0.snapshot
@@ -7,6 +7,7 @@ module From_202008241_to_202103001 = struct
 
 include Realistic_user_fns.From_202008241_to_202103001
 type converter = Realistic_upgrader_t.From_202008241_to_202103001.converter
+
 let convert_variable_ref_type _ _ x = x
 let convert_variable_ref: converter -> OldVersion.dialog_file -> OldVersion.variable_ref -> NewVersion.variable_ref = fun _ _  x -> Obj.magic x
 let convert_grammar_case _ _ x = x
@@ -140,6 +141,7 @@ module From_202103001_to_202103115 = struct
 
 include Realistic_user_fns.From_202103001_to_202103115
 type converter = Realistic_upgrader_t.From_202103001_to_202103115.converter
+
 let convert_variable_ref_type _ _ x = x
 let convert_variable_ref: converter -> OldVersion.dialog_file -> OldVersion.variable_ref -> NewVersion.variable_ref = fun _ _  x -> Obj.magic x
 let convert_grammar_case _ _ x = x

--- a/test/_snapshots/Generator.9212c23f.0.snapshot
+++ b/test/_snapshots/Generator.9212c23f.0.snapshot
@@ -3,12 +3,12 @@ Generator › simple transitive change - user intf list snapshot
 module From_202008241_to_202103001 : sig
 module OldVersion : (module type of Realistic_202008241_t)
 module NewVersion : (module type of Realistic_202103001_t)
-type converter := Realistic_upgrader_t.From_202008241_to_202103001.converter
+type converter = Realistic_upgrader_t.From_202008241_to_202103001.converter
 val convert_dialog_file: converter -> OldVersion.dialog_file -> NewVersion.dialog_file
 end
 module From_202103001_to_202103115 : sig
 module OldVersion : (module type of Realistic_202103001_t)
 module NewVersion : (module type of Realistic_202103115_t)
-type converter := Realistic_upgrader_t.From_202103001_to_202103115.converter
+type converter = Realistic_upgrader_t.From_202103001_to_202103115.converter
 val convert_primitive_variable_type: converter -> OldVersion.dialog_file -> OldVersion.primitive_variable_type -> NewVersion.primitive_variable_type
 end

--- a/test/_snapshots/Generator.92fe88c4.0.snapshot
+++ b/test/_snapshots/Generator.92fe88c4.0.snapshot
@@ -7,7 +7,7 @@ val read_employee: Yojson.Safe.lexer_state -> Lexing.lexbuf -> Types.employee
 module From_1_to_2 : sig
 module OldVersion : (module type of Simple_transitive_change_1_t)
 module NewVersion : (module type of Simple_transitive_change_2_t)
-type converter := Simple_transitive_change_upgrader_t.From_1_to_2.converter
+type converter = Simple_transitive_change_upgrader_t.From_1_to_2.converter
 val converter: converter
 val convert: OldVersion.employee -> NewVersion.employee
 end

--- a/test/_snapshots/Generator.d5d69f4b.0.snapshot
+++ b/test/_snapshots/Generator.d5d69f4b.0.snapshot
@@ -7,6 +7,7 @@ module From_1_to_2 = struct
 
 include Rescript_simple_user_fns.From_1_to_2
 type converter = Rescript_simple_upgrader_t.From_1_to_2.converter
+
 let convert_employer: converter -> OldVersion.employee -> OldVersion.employer -> NewVersion.employer = fun converter old_doc -> function 
 | OldVersion.Self -> NewVersion.Self
 | OldVersion.Company payload -> NewVersion.Company (payload |> (convert_company converter old_doc))

--- a/test/custom_output_prefix/custom_output_prefix_user_fns.ml
+++ b/test/custom_output_prefix/custom_output_prefix_user_fns.ml
@@ -1,6 +1,5 @@
 module From_1_to_2 = struct
-  module OldVersion = Custom_output_prefix_1_t
-  module NewVersion = Custom_output_prefix_2_t
+  include Custom_output_prefix_upgrader_t.From_1_to_2
 
   let convert_company _ _ (old_company : OldVersion.company)
       : NewVersion.company

--- a/test/realistic_examples/realistic_user_fns.ml
+++ b/test/realistic_examples/realistic_user_fns.ml
@@ -1,10 +1,8 @@
 module From_202008241_to_202103001 = struct
-  module OldVersion = Realistic_202008241_t
-  module NewVersion = Realistic_202103001_t
-  module Upgrader_t = Realistic_upgrader_t.From_202008241_to_202103001
+  include Realistic_upgrader_t.From_202008241_to_202103001
 
   let convert_dialog_file
-      (converter : Upgrader_t.converter)
+      (converter : converter)
       (OldVersion.{ deploy_env; dialog; _ } as old_dialog_file)
     =
     NewVersion.
@@ -20,8 +18,7 @@ module From_202008241_to_202103001 = struct
 end
 
 module From_202103001_to_202103115 = struct
-  module OldVersion = Realistic_202103001_t
-  module NewVersion = Realistic_202103115_t
+  include Realistic_upgrader_t.From_202103001_to_202103115
 
   let convert_primitive_variable_type
       _ _ (old : OldVersion.primitive_variable_type)

--- a/test/simple_transitive_change/simple_transitive_change_user_fns.ml
+++ b/test/simple_transitive_change/simple_transitive_change_user_fns.ml
@@ -1,6 +1,5 @@
 module From_1_to_2 = struct
-  module OldVersion = Simple_transitive_change_1_t
-  module NewVersion = Simple_transitive_change_2_t
+  include Simple_transitive_change_upgrader_t.From_1_to_2
 
   let convert_company _ _ (old_company : OldVersion.company)
       : NewVersion.company


### PR DESCRIPTION
This feature is OCaml 4.08 but Rescript is on 4.06