### PR TITLE
Remove double declaration of type $converter

### DIFF
--- a/lib/upgrader.ml
+++ b/lib/upgrader.ml
@@ -651,13 +651,9 @@ let make ~prefix ~old_file ~old_file_version ~new_file ~new_file_version =
     let user_fns_module =
       [%string "$(user_fns_module_name prefix).$module_name"]
     in
-    let impl_header =
-      [%string
-        {|
+    let impl_header = [%string {|
 include $user_fns_module
-type $converter = $upgrader_t.$module_name.$converter
-|}]
-    in
+|}] in
     let intf_header =
       [%string
         {|module $old_version : (module type of $old_version_t)

--- a/test/_snapshots/Generator.280d3627.0.snapshot
+++ b/test/_snapshots/Generator.280d3627.0.snapshot
@@ -6,7 +6,6 @@ module Json = Simple_transitive_change_2_j
 module From_1_to_2 = struct
 
 include Simple_transitive_change_user_fns.From_1_to_2
-type converter = Simple_transitive_change_upgrader_t.From_1_to_2.converter
 
 let convert_employer: converter -> OldVersion.employee -> OldVersion.employer -> NewVersion.employer = fun converter old_doc -> function 
 | OldVersion.Self -> NewVersion.Self

--- a/test/_snapshots/Generator.6e7eb4f2.0.snapshot
+++ b/test/_snapshots/Generator.6e7eb4f2.0.snapshot
@@ -6,7 +6,6 @@ module Json = Realistic_202103115_j
 module From_202008241_to_202103001 = struct
 
 include Realistic_user_fns.From_202008241_to_202103001
-type converter = Realistic_upgrader_t.From_202008241_to_202103001.converter
 
 let convert_variable_ref_type _ _ x = x
 let convert_variable_ref: converter -> OldVersion.dialog_file -> OldVersion.variable_ref -> NewVersion.variable_ref = fun _ _  x -> Obj.magic x
@@ -140,7 +139,6 @@ end
 module From_202103001_to_202103115 = struct
 
 include Realistic_user_fns.From_202103001_to_202103115
-type converter = Realistic_upgrader_t.From_202103001_to_202103115.converter
 
 let convert_variable_ref_type _ _ x = x
 let convert_variable_ref: converter -> OldVersion.dialog_file -> OldVersion.variable_ref -> NewVersion.variable_ref = fun _ _  x -> Obj.magic x

--- a/test/_snapshots/Generator.ba0d7484.0.snapshot
+++ b/test/_snapshots/Generator.ba0d7484.0.snapshot
@@ -6,7 +6,6 @@ module Json = Nominal_variant_2_j
 module From_1_to_2 = struct
 
 include Nominal_variant_user_fns.From_1_to_2
-type converter = Nominal_variant_upgrader_t.From_1_to_2.converter
 
 let convert_variant: converter -> OldVersion.json -> OldVersion.variant -> NewVersion.variant = fun _ _  x -> Obj.magic x
 let converter = Nominal_variant_upgrader_t.From_1_to_2.{ convert_json;

--- a/test/_snapshots/Generator.d5d69f4b.0.snapshot
+++ b/test/_snapshots/Generator.d5d69f4b.0.snapshot
@@ -6,7 +6,6 @@ module Json = Rescript_simple_2_bs
 module From_1_to_2 = struct
 
 include Rescript_simple_user_fns.From_1_to_2
-type converter = Rescript_simple_upgrader_t.From_1_to_2.converter
 
 let convert_employer: converter -> OldVersion.employee -> OldVersion.employer -> NewVersion.employer = fun converter old_doc -> function 
 | OldVersion.Self -> NewVersion.Self


### PR DESCRIPTION
I think it was not a problem since some OCaml version
but at 4.06 it errors. Removing it retains the same semantics because
type converter is included in user_fns_module