### PR TITLE
Use opam 2.1 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM ocaml/opam:ubuntu-22.04-ocaml-4.14 as app
 
 WORKDIR /app
 
-RUN sudo apt -y install pkg-config libpcre3-dev opam
+RUN sudo apt -y install pkg-config libpcre3-dev
+RUN sudo ln -f /usr/bin/opam-2.1 /usr/bin/opam
 
 COPY stork.opam stork.opam.dev.locked ./
 RUN opam repo set-url default https://opam.ocaml.org


### PR DESCRIPTION
There's no need to update opam, it already comes installed with the image, you only have to link to it.